### PR TITLE
Upload unsigned taco version as `spice_unsigned.taco`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,10 @@ jobs:
         run: |
           brew install make
 
-      - name: Package
+      - name: Package (unsigned)
         run: |
           make package
+          mv spice.taco spice_unsigned.taco
 
       - name: Upload
         uses: softprops/action-gh-release@v2
@@ -32,4 +33,4 @@ jobs:
           draft: true
           prerelease: true
           fail_on_unmatched_files: true
-          files: spice.taco
+          files: spice_unsigned.taco


### PR DESCRIPTION
## 🗣 Description

Use a separate name for the unsigned package version (`spice_unsigned.taco`) to simplify adding the signed version.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
